### PR TITLE
Close all client TCP sockets when the WiFi is disconnected, this avoids hangs in WiFiClient::connect

### DIFF
--- a/arduino/libraries/WiFi/src/WiFi.cpp
+++ b/arduino/libraries/WiFi/src/WiFi.cpp
@@ -38,7 +38,8 @@ WiFiClass::WiFiClass() :
   _initialized(false),
   _status(WL_NO_SHIELD),
   _interface(ESP_IF_WIFI_STA),
-  _onReceiveCallback(NULL)
+  _onReceiveCallback(NULL),
+  _onDisconnectCallback(NULL)
 {
   _eventGroup = xEventGroupCreate();
   memset(&_apRecord, 0x00, sizeof(_apRecord));
@@ -533,6 +534,11 @@ void WiFiClass::onReceive(void(*callback)(void))
   _onReceiveCallback = callback;
 }
 
+void WiFiClass::onDisconnect(void(*callback)(void))
+{
+  _onDisconnectCallback = callback;
+}
+
 err_t WiFiClass::staNetifInputHandler(struct pbuf* p, struct netif* inp)
 {
   return WiFi.handleStaNetifInput(p, inp);
@@ -651,6 +657,10 @@ void WiFiClass::handleSystemEvent(system_event_t* event)
         esp_wifi_connect();
       } else {
         _status = WL_DISCONNECTED;
+
+        if (_onDisconnectCallback) {
+          _onDisconnectCallback();
+        }
       }
       break;
     }

--- a/arduino/libraries/WiFi/src/WiFi.h
+++ b/arduino/libraries/WiFi/src/WiFi.h
@@ -96,6 +96,7 @@ public:
   void noLowPowerMode();
 
   void onReceive(void(*)(void));
+  void onDisconnect(void(*)(void));
 
 private:
   void init();
@@ -123,6 +124,7 @@ private:
   netif_input_fn _apNetifInput;
 
   void (*_onReceiveCallback)(void);
+  void (*_onDisconnectCallback)(void);
 };
 
 extern WiFiClass WiFi;

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -1016,6 +1016,7 @@ void CommandHandlerClass::begin()
   _updateGpio0PinSemaphore = xSemaphoreCreateCounting(2, 0);
 
   WiFi.onReceive(CommandHandlerClass::onWiFiReceive);
+  WiFi.onDisconnect(CommandHandlerClass::onWiFiDisconnect);
 
   xTaskCreatePinnedToCore(CommandHandlerClass::gpio0Updater, "gpio0Updater", 8192, NULL, 1, NULL, 1);
 }
@@ -1101,6 +1102,18 @@ void CommandHandlerClass::onWiFiReceive()
 void CommandHandlerClass::handleWiFiReceive()
 {
   xSemaphoreGiveFromISR(_updateGpio0PinSemaphore, NULL);
+}
+
+void CommandHandlerClass::onWiFiDisconnect()
+{
+  CommandHandler.handleWiFiDisconnect();
+}
+
+void CommandHandlerClass::handleWiFiDisconnect()
+{
+  for (int i = 0; i < MAX_SOCKETS; i++) {
+    tcpClients[i].stop();
+  }
 }
 
 CommandHandlerClass CommandHandler;

--- a/main/CommandHandler.h
+++ b/main/CommandHandler.h
@@ -36,6 +36,9 @@ private:
   static void onWiFiReceive();
   void handleWiFiReceive();
 
+  static void onWiFiDisconnect();
+  void handleWiFiDisconnect();
+
 private:
   SemaphoreHandle_t _updateGpio0PinSemaphore;
 };


### PR DESCRIPTION
Resolves https://github.com/arduino-libraries/WiFiNINA/issues/48.

The call to `lwip_connect_r` was hanging. Note, the SSL socket doesn't seem to have this issue.