### PR TITLE
fix setHostname API

### DIFF
--- a/arduino/libraries/WiFi/src/WiFi.h
+++ b/arduino/libraries/WiFi/src/WiFi.h
@@ -44,6 +44,7 @@ typedef enum {
 } wl_status_t;
 
 #define MAX_SCAN_RESULTS 10
+#define HOSTNAME_MAX_LENGTH 32
 
 class WiFiClass
 {
@@ -122,7 +123,7 @@ private:
   bool _staticIp;
   tcpip_adapter_ip_info_t _ipInfo;
   uint32_t _dnsServers[2];
-
+  char _hostname[HOSTNAME_MAX_LENGTH+1];
   netif_input_fn _staNetifInput;
   netif_input_fn _apNetifInput;
 


### PR DESCRIPTION
fixed set host name API now allow to set a hostname with max length 32 characters, otherwise set the default one

cc/ @sandeepmistry @facchinm i have tested with uno and 1010 and works could you double check?