### PR TITLE
Remove packet parsing from availDataTcp() function to avoid packets corruption

### DIFF
--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -483,10 +483,6 @@ int availDataTcp(const uint8_t command[], uint8_t response[])
     }
   } else if (socketTypes[socket] == 0x01) {
     available = udps[socket].available();
-
-    if (available <= 0) {
-      available = udps[socket].parsePacket();
-    }
   } else if (socketTypes[socket] == 0x02) {
     available = tlsClients[socket].available();
   }


### PR DESCRIPTION
This modification is intended to solve issues (#48 and [#WIFININA/108](https://github.com/arduino-libraries/WiFiNINA/issues/108)) related to corruption of udp packets, in particular with Uno WiFi Rev2. Indeed, when the packets frame rate was high, sooner or later the packets started to be corrupted.
This problem was due to the fact that _parsePacket()_ (the function to parse a new UDP packet) was called in 2 places: 
- by the thread gpio0Updater() which runs continuously
- by the _availDataTcp()_, the function that checks for available bytes to read: when the number of available bytes was 0, the fw tried to parse another packet.
Then, sometimes it could happen that the message stored in the buffer and the information about the length of the message went out of sync because of this. This means that, if the sender is alternating these 2 messages:
- "helloWORLD" (packetSize = 10)
- "goodbye" (packetSize = 7)
the receiver could see at a certain point or
- packetSize = 7 : "helloWO"
or
- packetSize = 10 : "goodbyeRLD"
Once the first error happened, from that moment on, the pointer to the right position of the messages in the buffer became totally misaligned, leading to a series of erroneous messages.

Here is the link to the Firmware Updater: https://github.com/arduino/FirmwareUpdater/releases/tag/0.0.6
Here is the binary: [NINA_W102_unowifirev2.bin.zip](https://github.com/arduino/nina-fw/files/4865559/NINA_W102_unowifirev2.bin.zip)

This fixes #48.