### PR TITLE
Fix issue due to repeated status()/connected() call

### DIFF
--- a/arduino/libraries/WiFi/src/WiFiClient.cpp
+++ b/arduino/libraries/WiFi/src/WiFiClient.cpp
@@ -105,6 +105,7 @@ int WiFiClient::available()
 
   int result = 0;
 
+  //This function returns the number of bytes of pending data already received in the socket’s network.
   if (lwip_ioctl_r(_socket, FIONREAD, &result) < 0) {
     lwip_close_r(_socket);
     _socket = -1;
@@ -150,6 +151,7 @@ int WiFiClient::peek()
 {
   uint8_t b;
 
+  //This function tries to receive data from the network and can return an error if the connection when down.
   if (lwip_recv_r(_socket, &b, sizeof(b), MSG_PEEK | MSG_DONTWAIT) <= 0) {
     if (errno != EWOULDBLOCK) {
       lwip_close_r(_socket);
@@ -177,7 +179,10 @@ void WiFiClient::stop()
 uint8_t WiFiClient::connected()
 {
   if (_socket != -1) {
-    available();
+    //Check if there are already available data and, if not, try to read new ones from the network.
+    if (!available()) {
+      peek();
+    }
   }
 
   return (_socket != -1);

--- a/arduino/libraries/WiFi/src/WiFiClient.cpp
+++ b/arduino/libraries/WiFi/src/WiFiClient.cpp
@@ -177,7 +177,7 @@ void WiFiClient::stop()
 uint8_t WiFiClient::connected()
 {
   if (_socket != -1) {
-    peek();
+    available();
   }
 
   return (_socket != -1);


### PR DESCRIPTION
When a sketch repeatedly calls `client.status()` and `client.connected()` functions, the connection occasionally gets stuck.
This issue had already been address by PR #50 ,which was then reverted thinking that its functionality was already covered by further code modifications.
Unfortunately it still seems to be needed.
A further modification has been introduce to let the driver correctly detect a client disconnection. In order to avoid lockups, we need to call `available()` function. This function, calling `lwip_ioctl_r()`, returns the number of bytes of pending data **already** received in the socket’s network. At most the result is 0. However, `available()` is never able to detect a network disconnection.
`peek()` , on the other hand, is the function to call to receive data with `lwip_recv_r()`. This function can actually return an error if the connection went down.
The procedure adopted here is to check if there are already available data and, if not, try to read from the network. In this way we avoid lockups by always checking if there are already available data before trying to receive new ones and we are also able to detect a disconnection.