### PR TITLE
support server.accept() for WiFiNINA library

### DIFF
--- a/arduino/libraries/WiFi/src/WiFiServer.cpp
+++ b/arduino/libraries/WiFi/src/WiFiServer.cpp
@@ -74,7 +74,13 @@ void WiFiServer::begin()
 
 WiFiClient WiFiServer::available(uint8_t* status)
 {
-  int result = lwip_accept(_socket, NULL, 0);
+  int result = -1;
+  if (_accepted_sock >= 0) {
+    result = _accepted_sock;
+    _accepted_sock = -1;
+  } else {
+    result = lwip_accept(_socket, NULL, 0);
+  }
 
   if (status) {
     *status = (result != -1);
@@ -109,6 +115,25 @@ WiFiClient WiFiServer::available(uint8_t* status)
   }
 
   return WiFiClient(result);
+}
+
+WiFiClient WiFiServer::accept()
+{
+  int result = -1;
+  if (_accepted_sock >= 0) {
+    result = _accepted_sock;
+    _accepted_sock = -1;
+  } else {
+    result = lwip_accept(_socket, NULL, 0);
+  }
+  return WiFiClient(result);
+}
+
+bool WiFiServer::hasClient() {
+  if (_accepted_sock != -1) 
+    return true;
+  _accepted_sock = lwip_accept(_socket, NULL, 0);
+  return (_accepted_sock != -1);
 }
 
 uint8_t WiFiServer::status() {

--- a/arduino/libraries/WiFi/src/WiFiServer.h
+++ b/arduino/libraries/WiFi/src/WiFiServer.h
@@ -32,6 +32,8 @@ public:
   WiFiServer();
   WiFiServer(uint16_t);
   WiFiClient available(uint8_t* status = NULL);
+  WiFiClient accept();
+  bool hasClient();
   void begin();
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
@@ -45,6 +47,7 @@ private:
   uint16_t _port;
   int _socket;
   int _spawnedSockets[CONFIG_LWIP_MAX_SOCKETS];
+  int _accepted_sock = -1;
 };
 
 #endif // WIFISERVER_H

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -454,10 +454,24 @@ int availDataTcp(const uint8_t command[], uint8_t response[])
 
   if (socketTypes[socket] == 0x00) {
     if (tcpServers[socket]) {
-      WiFiClient client = tcpServers[socket].available();
 
+      uint8_t accept = command[6];
       available = 255;
 
+      if (accept) {
+        for (int i = 0; i < MAX_SOCKETS; i++) {
+          if (socketTypes[i] == 255) {
+            WiFiClient client = tcpServers[socket].accept();
+            if (client) {
+              socketTypes[i] = 0x00;
+              tcpClients[i] = client;
+              available = i;
+            }
+            break;
+          }
+        }
+     } else {
+      WiFiClient client = tcpServers[socket].available();
       if (client) {
         // try to find existing socket slot
         for (int i = 0; i < MAX_SOCKETS; i++) {
@@ -489,6 +503,7 @@ int availDataTcp(const uint8_t command[], uint8_t response[])
           }
         }
       }
+     }
     } else {
       available = tcpClients[socket].available();
     }
@@ -1680,7 +1695,7 @@ void CommandHandlerClass::updateGpio0Pin()
 
   for (int i = 0; i < MAX_SOCKETS; i++) {
     if (socketTypes[i] == 0x00) {
-      if (tcpServers[i] && tcpServers[i].available()) {
+      if (tcpServers[i] && (tcpServers[i].hasClient() || tcpServers[i].available())) {
         available = 1;
         break;
       } else if (tcpClients[i] && tcpClients[i].connected() && tcpClients[i].available()) {


### PR DESCRIPTION
A PR in WiFiNINA library follows.

There are almost no comments in the fw source code so I didn't add any too. But it is not too complicated. The only catch is that `CommandHandlerClass::updateGpio0Pin` periodically calls server.available() which accepts clients for _spawnedSockets (available() and write-to-all clients management). A new function server.hasClient (inspired by the ESP32 core WiFi library's WiFiServer) is used to outrun available() in accepting a new client from updateGpio0Pin. If after IRQ pin is activated, the sketch calls accept(), the pre-accepted client is returned and not used for _spawnedSockets. If available() is called from sketch, then the pre-accepted socket is added to _spawnedSockets. 

btw: WiFiServer::available() should be rewritten to only get new clients if there is a slot in _spawnedSockets.