### PR TITLE
fix a compatibility problem with server.accept() support

### DIFF
--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -457,7 +457,7 @@ int availDataTcp(const uint8_t command[], uint8_t response[])
   if (socketTypes[socket] == 0x00) {
     if (tcpServers[socket]) {
 
-      uint8_t accept = command[6];
+      uint8_t accept = command[2] == 2 ? command[6] : 0; // updated library sends a second parameter
       available = 255;
 
       if (accept) {


### PR DESCRIPTION
something went wrong when I more than a year ago tested the PR with support for server.accept behavior with a WiFiNINA library version which doesn't have server.accept support yet. I missed that END_CMD in the commandBuffer always sets `accept` to true in availDataTcp. It looked like availDataTcp is all zeros after the last received parameter so `accept` will be false.

So now with fw 1.5.0 the server.available() always works like server.accept(), because the current version of the library asks for fw 1.5.0 but doesn't have the PR https://github.com/arduino-libraries/WiFiNINA/pull/204 with support of server.accept merged.