### PR TITLE
Client connect timeout support

### DIFF
--- a/arduino/libraries/WiFi/src/WiFiClient.h
+++ b/arduino/libraries/WiFi/src/WiFiClient.h
@@ -50,6 +50,8 @@ public:
   virtual /*IPAddress*/uint32_t remoteIP();
   virtual uint16_t remotePort();
 
+  void setConnectionTimeout(uint16_t timeout) {_connTimeout = timeout;}
+
   // using Print::write;
 
 protected:
@@ -59,6 +61,7 @@ protected:
 
 private:
   int _socket;
+  uint16_t _connTimeout = 0;
 };
 
 #endif // WIFICLIENT_H

--- a/arduino/libraries/WiFi/src/WiFiSSLClient.h
+++ b/arduino/libraries/WiFi/src/WiFiSSLClient.h
@@ -55,6 +55,8 @@ public:
   virtual /*IPAddress*/uint32_t remoteIP();
   virtual uint16_t remotePort();
 
+  void setConnectionTimeout(uint16_t timeout) {_connTimeout = timeout;}
+
 private:
   int connect(const char* host, uint16_t port, bool sni);
 
@@ -69,6 +71,7 @@ private:
   mbedtls_x509_crt _caCrt;
   bool _connected;
   int _peek;
+  uint16_t _connTimeout = 0;
 
   SemaphoreHandle_t _mbedMutex;
 };

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -595,6 +595,7 @@ int startClientTcp(const uint8_t command[], uint8_t response[])
   uint16_t port;
   uint8_t socket;
   uint8_t type;
+  uint16_t timeout = 0;
 
   memset(host, 0x00, sizeof(host));
 
@@ -611,10 +612,15 @@ int startClientTcp(const uint8_t command[], uint8_t response[])
     port = ntohs(port);
     socket = command[13 + command[3]];
     type = command[15 + command[3]];
+    if (command[2] == 6) { // optional sixth parameter
+      timeout = (uint16_t) command[17 + command[3]] << 8 | command[18 + command[3]];
+    }
   }
 
   if (type == 0x00) {
     int result;
+
+    tcpClients[socket].setConnectionTimeout(timeout);
 
     if (host[0] != '\0') {
       result = tcpClients[socket].connect(host, port);
@@ -660,6 +666,8 @@ int startClientTcp(const uint8_t command[], uint8_t response[])
   } else if (type == 0x02) {
     int result;
 
+    tlsClients[socket].setConnectionTimeout(timeout);
+
     if (host[0] != '\0') {
       result = tlsClients[socket].connect(host, port);
     } else {
@@ -683,6 +691,8 @@ int startClientTcp(const uint8_t command[], uint8_t response[])
     int result;
 
     configureECCx08();
+
+    static_cast<WiFiClient*>(bearsslClient.getClient())->setConnectionTimeout(timeout);
 
     if (host[0] != '\0') {
       result = bearsslClient.connect(host, port);


### PR DESCRIPTION
Client connect timeout is very useful if the other device may be out of reach. Then the default timeout of LwIP is too long (looks like it is 18 seconds).

The PR adds the support for the timeout in WiFiNINA. The new code is only active if timeout is not 0. With timeout 0 it works like before.

The timeout version of connect is based on the code from the esp32 Arduino WiFi library, which is based on IDF examples. It looks like many lines, but it is just detailed error detection and logging which I didn't want to throw away.