### PR TITLE
server.end() support

### DIFF
--- a/arduino/libraries/WiFi/src/WiFiServer.cpp
+++ b/arduino/libraries/WiFi/src/WiFiServer.cpp
@@ -41,6 +41,8 @@ uint8_t WiFiServer::begin(uint16_t port)
   if (_socket < 0) {
     return 0;
   }
+  int enable = 1;
+  setsockopt(_socket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
 
   struct sockaddr_in addr;
   memset(&addr, 0x00, sizeof(addr));
@@ -68,6 +70,22 @@ uint8_t WiFiServer::begin(uint16_t port)
   _port = port;
 
   return 1;
+}
+
+
+void WiFiServer::end()
+{
+  if (_socket != -1) {
+    for (int i = 0; i < CONFIG_LWIP_MAX_SOCKETS; i++) {
+      if (_spawnedSockets[i] != -1) {
+        lwip_close_r(_spawnedSockets[i]);
+        _spawnedSockets[i] = -1;
+      }
+    }
+    lwip_close_r(_socket);
+    _socket = -1;
+  }
+  _accepted_sock = -1;
 }
 
 WiFiClient WiFiServer::available(uint8_t* status)

--- a/arduino/libraries/WiFi/src/WiFiServer.h
+++ b/arduino/libraries/WiFi/src/WiFiServer.h
@@ -34,6 +34,7 @@ public:
   WiFiClient accept();
   bool hasClient();
   uint8_t begin(uint16_t port);
+  void end();
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *buf, size_t size);
   uint8_t status();
@@ -47,6 +48,11 @@ private:
   int _socket;
   int _spawnedSockets[CONFIG_LWIP_MAX_SOCKETS];
   int _accepted_sock = -1;
+
+public:
+  WiFiClient getSpawnedClient(int i) {
+    return WiFiClient(_spawnedSockets[i]);
+  }
 };
 
 #endif // WIFISERVER_H

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -438,6 +438,32 @@ int startServerTcp(const uint8_t command[], uint8_t response[])
   return 6;
 }
 
+int stopServerTcp(const uint8_t command[], uint8_t response[])
+{
+  uint8_t socket = command[4];
+
+  for (int i = 0; i < CONFIG_LWIP_MAX_SOCKETS; i++) {
+    WiFiClient c(tcpServers[socket].getSpawnedClient(i));
+    if (c) {
+      for (int j = 0; j < MAX_SOCKETS; j++) {
+        if (tcpClients[j] == c) {
+          socketTypes[j] = 255;
+          tcpClients[i] = WiFiClient();
+          break;
+        }
+      }
+    }
+  }
+  tcpServers[socket].end();
+  socketTypes[socket] = 255;
+
+  response[2] = 1; // number of parameters
+  response[3] = 1; // parameter 1 length
+  response[4] = 1; // parameter 1 length
+
+  return 6;
+}
+
 int getStateTcp(const uint8_t command[], uint8_t response[])
 {
   uint8_t socket = command[4];
@@ -2083,7 +2109,7 @@ const CommandHandlerType commandHandlers[] = {
   getConnStatus, getIPaddr, getMACaddr, getCurrSSID, getCurrBSSID, getCurrRSSI, getCurrEnct, scanNetworks, startServerTcp, getStateTcp, dataSentTcp, availDataTcp, getDataTcp, startClientTcp, stopClientTcp, getClientStateTcp,
 
   // 0x30 -> 0x3f
-  disconnect, NULL, getIdxRSSI, getIdxEnct, reqHostByName, getHostByName, startScanNetworks, getFwVersion, NULL, sendUDPdata, getRemoteData, getTime, getIdxBSSID, getIdxChannel, ping, getSocket,
+  disconnect, NULL, getIdxRSSI, getIdxEnct, reqHostByName, getHostByName, startScanNetworks, getFwVersion, stopServerTcp, sendUDPdata, getRemoteData, getTime, getIdxBSSID, getIdxChannel, ping, getSocket,
 
   // 0x40 -> 0x4f
   setEnt, NULL, NULL, NULL, sendDataTcp, getDataBufTcp, insertDataBuf, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,


### PR DESCRIPTION
Support for WiFiServer::end in the WiFiNINA library.

In stopServerTcp the CommandHandler has to clear the records for clients closed by the server in end(). But that information is only in the server object so I had to make it available with getSpawnedClient(i).

In WiFiServer.begin the setsockopt SO_REUSEADDR is a standard trick for BSD sockets to allow listen on a port again.
