### PR TITLE
Add opt-in all-channel scan for station mode (SET_SCAN_MODE, 0x13)

### DIFF
--- a/arduino/libraries/WiFi/src/WiFi.cpp
+++ b/arduino/libraries/WiFi/src/WiFi.cpp
@@ -185,6 +185,11 @@ uint8_t WiFiClass::begin(const char* ssid, uint8_t key_idx, const char* key)
   return begin(ssid, key);
 }
 
+void WiFiClass::scanMode(uint8_t scanMode)
+{
+  _scanMode = scanMode;
+}
+
 uint8_t WiFiClass::begin(const char* ssid, const char* key)
 {
   wifi_config_t wifiConfig;
@@ -192,7 +197,11 @@ uint8_t WiFiClass::begin(const char* ssid, const char* key)
   memset(&wifiConfig, 0x00, sizeof(wifiConfig));
   strncpy((char*)wifiConfig.sta.ssid, ssid, sizeof(wifiConfig.sta.ssid));
   strncpy((char*)wifiConfig.sta.password, key, sizeof(wifiConfig.sta.password));
-  wifiConfig.sta.scan_method = WIFI_FAST_SCAN;
+  wifiConfig.sta.scan_method = (wifi_scan_method_t)_scanMode;
+  if (_scanMode == WIFI_ALL_CHANNEL_SCAN) {
+    // every channel has been heard, so let the strongest AP win
+    wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+  }
   _status = WL_NO_SSID_AVAIL;
 
   _interface = WIFI_IF_STA;

--- a/arduino/libraries/WiFi/src/WiFi.h
+++ b/arduino/libraries/WiFi/src/WiFi.h
@@ -55,6 +55,11 @@ public:
   uint8_t begin(const char* ssid, uint8_t key_idx, const char* key);
   uint8_t begin(const char* ssid, const char* key);
 
+  // Station scan mode used by the next begin(): WIFI_FAST_SCAN (default)
+  // joins the first matching AP found; WIFI_ALL_CHANNEL_SCAN scans every
+  // channel and joins the strongest matching AP.
+  void scanMode(uint8_t scanMode);
+
   uint8_t beginAP(const char *ssid, uint8_t channel);
   uint8_t beginAP(const char *ssid, uint8_t key_idx, const char* key, uint8_t channel);
   uint8_t beginAP(const char *ssid, const char* key, uint8_t channel);
@@ -116,6 +121,7 @@ private:
 
 private:
   bool _initialized;
+  uint8_t _scanMode = WIFI_FAST_SCAN;
   volatile uint8_t _status;
   volatile uint8_t _reasonCode;
   EventGroupHandle_t _eventGroup;

--- a/main/CommandHandler.cpp
+++ b/main/CommandHandler.cpp
@@ -183,6 +183,17 @@ int setPowerMode(const uint8_t command[], uint8_t response[])
   return 6;
 }
 
+int setScanMode(const uint8_t command[], uint8_t response[])
+{
+  WiFi.scanMode(command[4]);
+
+  response[2] = 1; // number of parameters
+  response[3] = 1; // parameter 1 length
+  response[4] = 1;
+
+  return 6;
+}
+
 int setApNet(const uint8_t command[], uint8_t response[])
 {
   char ssid[32 + 1];
@@ -2884,7 +2895,7 @@ const CommandHandlerType commandHandlers[] = {
   NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
 
   // 0x10 -> 0x1f
-  setNet, setPassPhrase, setKey, NULL, setIPconfig, setDNSconfig, setHostname, setPowerMode, setApNet, setApPassPhrase, setDebug, getTemperature, NULL, NULL, getDNSconfig, getReasonCode,
+  setNet, setPassPhrase, setKey, setScanMode, setIPconfig, setDNSconfig, setHostname, setPowerMode, setApNet, setApPassPhrase, setDebug, getTemperature, NULL, NULL, getDNSconfig, getReasonCode,
 
   // 0x20 -> 0x2f
   getConnStatus, getIPaddr, getMACaddr, getCurrSSID, getCurrBSSID, getCurrRSSI, getCurrEnct, scanNetworks, startServerTcp, getStateTcp, dataSentTcp, availDataTcp, getDataTcp, startClientTcp, stopClientTcp, getClientStateTcp,


### PR DESCRIPTION
## Motivation

As reported in #75 and discussed in #118, station mode uses `WIFI_FAST_SCAN`, which joins the **first** matching AP found scanning channels in ascending order. On networks where several APs broadcast one SSID (mesh, enterprise, UniFi and similar), this routinely selects a distant AP over a strong nearby one, and the association then sticks there.

In #118, @andreagilardoni asked for this to be implemented as an **opt-in API rather than a default change**:

> I suggest you to add a new command in CommandHandler.cpp adapting a command like `setPassPhrase` and add in `wifi::begin` a new default parameter scan mode (with WIFI_FAST_SCAN default).

This PR implements that, together with a companion WiFiNINA PR (linked below).

## What this does

* New command **`SET_SCAN_MODE` = `0x13`** (the long-unused former `TEST_CMD` slot, free in both this table and WiFiNINA's enum). One 1-byte parameter, values matching ESP-IDF's `wifi_scan_method_t`:
  * `0` = `WIFI_FAST_SCAN` — **default, behavior unchanged for existing sketches**
  * `1` = `WIFI_ALL_CHANNEL_SCAN`, with `sort_method = WIFI_CONNECT_AP_BY_SIGNAL` so the strongest matching AP wins
* `WiFiClass::scanMode(uint8_t)` stores the mode; all station `begin()` variants apply it (they funnel through `begin(ssid, key)`). Not persisted — each boot starts at fast scan unless the sketch opts in.
* Old firmware + new library degrades gracefully: the library call returns `false` (error frame from the NULL handler) and fast scan remains in effect.

## Field data (why this matters)

Measured on a MKR WiFi 1010 in a venue with three UniFi APs broadcasting one SSID on 2.4 GHz:

| what the same radio saw at the same moment | |
|---|---|
| scan: nearest AP, **ch 11** | **−61 dBm** |
| scan: two far APs, **ch 6** | −81 dBm |
| association result (fast scan) | joins a ch 6 AP at −77..−84, five consecutive reconnects |

Because both weak APs sit on a lower channel than the strong one, fast scan finds them first every time. The weak associations then caused TLS transfers slow enough to trip the host's watchdog. A device-side workaround does not exist: retrying `begin()` re-runs the same sweep, and the API cannot join by BSSID.

## Testing

The companion WiFiNINA change compiles for SAMD21 targets. Opening as **draft** until I have validated the built firmware end-to-end on MKR WiFi 1010 hardware against the same multi-AP network; will report results here.

Companion library PR: arduino-libraries/WiFiNINA#332